### PR TITLE
Change to x11 display only

### DIFF
--- a/tw.ddnet.ddnet.yml
+++ b/tw.ddnet.ddnet.yml
@@ -10,8 +10,7 @@ finish-args:
   - --persist=.teeworlds
   - --share=ipc
   - --share=network
-  - --socket=wayland
-  - --socket=fallback-x11
+  - --socket=x11
   - --socket=pulseaudio
   - --talk-name=org.freedesktop.Notifications
 rename-desktop-file: ddnet.desktop


### PR DESCRIPTION
Removing Wayland and fallback-x11, as the SDL is not able to detect the Wayland session under the sandbox for some reason that I could not figure out. And now, it cannot detect X11 as a fallback.

I'll continue the troubleshooting on https://github.com/ddnet/ddnet/issues/3797.

Merging this PR as the game is not opening anymore.